### PR TITLE
make sure to expand path

### DIFF
--- a/autoload/session.vim
+++ b/autoload/session.vim
@@ -15,8 +15,8 @@ let g:loaded_lib_session = 1
 if !exists("g:session_dir")
 	let g:session_dir = $HOME . "/.vim_sessions"
 endif
-if !isdirectory(g:session_dir)
-	call mkdir(g:session_dir, "p")
+if !isdirectory(expand(g:session_dir))
+	call mkdir(expand(g:session_dir), "p")
 endif
 
 "


### PR DESCRIPTION
If g:session_dir has a character like `~` in it, e.g. `~/.vim/session`, a directory named literally `~` would be made in vim's CWD.
